### PR TITLE
Fix AllSettings when some map keys contain the key delimiter

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -1736,7 +1736,22 @@ func (v *Viper) AllSettings() map[string]interface{} {
 			// check just in case anything changes
 			continue
 		}
-		path := strings.Split(k, v.keyDelim)
+
+		// Build key path by splitting the key by keyDelim and checking that the parent keys
+		// are actually set.
+		// Example use case:
+		//   Ensures sure that, for the yaml conf "foo.bar: baz", and keyDelim ".":
+		//   the generated path is []string{"foo.bar", "baz"}, instead of []string{"foo", "bar", "baz"}
+		path := []string{}
+		splitPath := strings.Split(k, v.keyDelim)
+		i := 0
+		for j := range splitPath {
+			if v.IsSet(strings.Join(splitPath[:j+1], v.keyDelim)) {
+				path = append(path, strings.Join(splitPath[i:j+1], v.keyDelim))
+				i = j + 1
+			}
+		}
+
 		lastKey := strings.ToLower(path[len(path)-1])
 		deepestMap := deepSearch(m, path[0:len(path)-1])
 		// set innermost value

--- a/viper_test.go
+++ b/viper_test.go
@@ -500,6 +500,39 @@ func TestAllKeysWithEnv(t *testing.T) {
 	assert.Equal(t, expectedKeys, keys)
 }
 
+func TestAllSettingsWithDelimiterInKeys(t *testing.T) {
+	exampleYaml := `Hacker: true
+name: steve
+hobbies:
+- skate.boarding
+- snowboarding
+clothing.summer:
+  jacket: leather
+  pants:
+    size: large
+clothing.winter:
+  jacket: wool
+  pants:
+    size: medium
+`
+	v := New()
+	v.SetConfigType("yaml")
+	r := strings.NewReader(exampleYaml)
+
+	if err := v.unmarshalReader(r, v.config); err != nil {
+		panic(err)
+	}
+
+	expectedAll := map[string]interface{}{"hacker": true, "name": "steve", "hobbies": []interface{}{"skate.boarding", "snowboarding"}, "clothing.summer": map[string]interface{}{"jacket": "leather", "pants": map[string]interface{}{"size": "large"}}, "clothing.winter": map[string]interface{}{"jacket": "wool", "pants": map[string]interface{}{"size": "medium"}}}
+	expectedKeys := sort.StringSlice{"hacker", "name", "hobbies", "clothing.summer.jacket", "clothing.summer.pants.size", "clothing.winter.jacket", "clothing.winter.pants.size"}
+	expectedKeys.Sort()
+	keys := sort.StringSlice(v.AllKeys())
+	keys.Sort()
+
+	assert.Equal(t, expectedKeys, keys)
+	assert.Equal(t, expectedAll, v.AllSettings())
+}
+
 func TestAliasesOfAliases(t *testing.T) {
 	Set("Title", "Checking Case")
 	RegisterAlias("Foo", "Bar")


### PR DESCRIPTION
## What does this PR do?

Fixes the `AllSettings` function on config keys that contain the key delimiter.

Without this fix, a config such as:

```yaml
additional_endpoints:
  https://app.datadoghq.com:
    - someapikey
```

becomes, after being loaded and dumped with`AllSettings()`:

```yaml
additional_endpoints:
  https://app:
    datadoghq:
      com:
        - someapikey
```

This fix ensures that `AllSettings()` correctly handles such keys, and dumps a config that's unchanged from what was originally loaded.

## Additional notes

In general, we should likely avoid using the key delimiter in config keys. There are likely other functions of `viper` that don't handle that well the keys that contain the key delimiter.

This also means that going forward, we should avoid allowing config maps with arbitrary keys.