### PR TITLE
Fix module path declaration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/spf13/viper
+module github.com/DataDog/viper
 
 require (
 	github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6 // indirect


### PR DESCRIPTION
importing `github.com/DataDog/...` results in something like:
```
        ... imports
        github.com/DataDog/datadog-agent/pkg/config imports
        github.com/DataDog/viper: github.com/DataDog/viper@v1.7.0: parsing go.mod:
        module declares its path as: github.com/spf13/viper
                but was required as: github.com/DataDog/viper
```