### PR TITLE
Allow setting multiple environment variables for the same key.

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -194,7 +194,7 @@ type Viper struct {
 	defaults       map[string]interface{}
 	kvstore        map[string]interface{}
 	pflags         map[string]FlagValue
-	env            map[string]string
+	env            map[string][]string
 	aliases        map[string]string
 	knownKeys      map[string]interface{}
 	typeByDefValue bool
@@ -217,7 +217,7 @@ func New() *Viper {
 	v.defaults = make(map[string]interface{})
 	v.kvstore = make(map[string]interface{})
 	v.pflags = make(map[string]FlagValue)
-	v.env = make(map[string]string)
+	v.env = make(map[string][]string)
 	v.aliases = make(map[string]string)
 	v.knownKeys = make(map[string]interface{})
 	v.typeByDefValue = false
@@ -1023,21 +1023,20 @@ func (v *Viper) BindFlagValue(key string, flag FlagValue) error {
 // EnvPrefix will be used when set when env name is not provided.
 func BindEnv(input ...string) error { return v.BindEnv(input...) }
 func (v *Viper) BindEnv(input ...string) error {
-	var key, envkey string
 	if len(input) == 0 {
 		return fmt.Errorf("BindEnv missing key to bind to")
 	}
 
-	key = strings.ToLower(input[0])
+	key := strings.ToLower(input[0])
+	var envkeys []string
 
 	if len(input) == 1 {
-		envkey = v.mergeWithEnvPrefix(key)
+		envkeys = []string{v.mergeWithEnvPrefix(key)}
 	} else {
-		envkey = input[1]
+		envkeys = input[1:]
 	}
 
-	v.env[key] = envkey
-
+	v.env[key] = append(v.env[key], envkeys...)
 	v.SetKnown(key)
 
 	return nil
@@ -1108,10 +1107,12 @@ func (v *Viper) find(lcaseKey string) interface{} {
 			return nil
 		}
 	}
-	envkey, exists := v.env[lcaseKey]
+	envkeys, exists := v.env[lcaseKey]
 	if exists {
-		if val, ok := v.getEnv(envkey); ok {
-			return val
+		for _, key := range envkeys {
+			if val, ok := v.getEnv(key); ok {
+				return val
+			}
 		}
 	}
 	if nested && v.isPathShadowedInFlatMap(path, v.env) != "" {
@@ -1629,6 +1630,14 @@ func castToMapStringInterface(
 	return tgt
 }
 
+func castMapStringSliceToMapInterface(src map[string][]string) map[string]interface{} {
+	tgt := map[string]interface{}{}
+	for k, v := range src {
+		tgt[k] = v
+	}
+	return tgt
+}
+
 func castMapStringToMapInterface(src map[string]string) map[string]interface{} {
 	tgt := map[string]interface{}{}
 	for k, v := range src {
@@ -1795,7 +1804,7 @@ func (v *Viper) AllKeys() []string {
 	m = v.flattenAndMergeMap(m, castMapStringToMapInterface(v.aliases), "")
 	m = v.flattenAndMergeMap(m, v.override, "")
 	m = v.mergeFlatMap(m, castMapFlagToMapInterface(v.pflags))
-	m = v.mergeFlatMap(m, castMapStringToMapInterface(v.env))
+	m = v.mergeFlatMap(m, castMapStringSliceToMapInterface(v.env))
 	m = v.flattenAndMergeMap(m, v.config, "")
 	m = v.flattenAndMergeMap(m, v.kvstore, "")
 	m = v.flattenAndMergeMap(m, v.defaults, "")
@@ -1850,7 +1859,7 @@ func (v *Viper) flattenAndMergeMap(shadow map[string]bool, m map[string]interfac
 func (v *Viper) mergeFlatMap(shadow map[string]bool, m map[string]interface{}) map[string]bool {
 	// scan keys
 outer:
-	for k, _ := range m {
+	for k := range m {
 		path := strings.Split(k, v.keyDelim)
 		// scan intermediate paths
 		var parentKey string

--- a/viper_test.go
+++ b/viper_test.go
@@ -383,10 +383,11 @@ func TestEnv(t *testing.T) {
 	initJSON(v)
 
 	v.BindEnv("id")
-	v.BindEnv("f", "FOOD")
+	v.BindEnv("f", "FOOD", "DEPRECATED_FOOD")
 
 	os.Setenv("ID", "13")
 	os.Setenv("FOOD", "apple")
+	os.Setenv("DEPRECATED_FOOD", "banana")
 	os.Setenv("NAME", "crunk")
 
 	assert.Equal(t, "13", v.Get("id"))
@@ -396,7 +397,27 @@ func TestEnv(t *testing.T) {
 	v.AutomaticEnv()
 
 	assert.Equal(t, "crunk", v.Get("name"))
+}
 
+func TestMultipleEnv(t *testing.T) {
+	v := New()
+	initJSON(v)
+
+	v.BindEnv("id")
+	v.BindEnv("f", "FOOD", "DEPRECATED_FOOD")
+
+	os.Setenv("ID", "13")
+	os.Unsetenv("FOOD")
+	os.Setenv("DEPRECATED_FOOD", "banana")
+	os.Setenv("NAME", "crunk")
+
+	assert.Equal(t, "13", v.Get("id"))
+	assert.Equal(t, "banana", v.Get("f"))
+	assert.Equal(t, "Cake", v.Get("name"))
+
+	v.AutomaticEnv()
+
+	assert.Equal(t, "crunk", v.Get("name"))
 }
 
 func TestEmptyEnv(t *testing.T) {

--- a/viper_test.go
+++ b/viper_test.go
@@ -399,6 +399,17 @@ func TestEnv(t *testing.T) {
 	assert.Equal(t, "crunk", v.Get("name"))
 }
 
+func TestEnvTransformer(t *testing.T) {
+	v := New()
+	initJSON(v)
+
+	v.BindEnv("id", "MY_ID")
+	v.SetEnvKeyTransformer("id", func(in string) interface{} { return "transformed" })
+	os.Setenv("MY_ID", "14")
+
+	assert.Equal(t, "transformed", v.Get("id"))
+}
+
 func TestMultipleEnv(t *testing.T) {
 	v := New()
 	initJSON(v)


### PR DESCRIPTION
### Changes

* Allow setting more than one env. variable into BindEnv.
* Allow setting value transformers which permit the modification of
an environment variable before being assigned to a key.

### Motivations:

The `trace-agent` is blocked from switching fully to the shared config because:

* We can't have multiple env. vars bound to the same key (we still
support deprecated ones for backwards compatibility and don't want
to remove that)
* The way an env. var. translates to its internal representation can be
different from Viper's standards (thus added `SetEnvKeyTransformer`)