### PR TITLE
Make AllKeys, AllSettings and IsSet consistent between them

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -1789,6 +1789,10 @@ func (v *Viper) flattenAndMergeMap(shadow map[string]bool, m map[string]interfac
 			shadow[strings.ToLower(fullKey)] = true
 			continue
 		}
+		if len(m2) == 0 {
+			// empty dict explicitly present in the map
+			shadow[strings.ToLower(fullKey)] = true
+		}
 		// recursively merge to shadow map
 		shadow = v.flattenAndMergeMap(shadow, m2, fullKey)
 	}

--- a/viper.go
+++ b/viper.go
@@ -1825,8 +1825,8 @@ func (v *Viper) AllSettings() map[string]interface{} {
 	for _, k := range v.AllKeys() {
 		value := v.Get(k)
 		if value == nil {
-			// should not happen, since AllKeys() returns only keys holding a value,
-			// check just in case anything changes
+			// Key set but empty, include it in the output as a null value
+			m[k] = nil
 			continue
 		}
 

--- a/viper.go
+++ b/viper.go
@@ -338,6 +338,16 @@ func (v *Viper) getEnv(key string) (string, bool) {
 	return val, ok && (v.allowEmptyEnv || val != "")
 }
 
+func (v *Viper) getAllEnvBoundAndSet() map[string]interface{} {
+	tgt := map[string]interface{}{}
+	for key, value := range v.env {
+		if _, ok := v.getEnv(v.mergeWithEnvPrefix(key)); ok {
+			tgt[key] = value
+		}
+	}
+	return tgt
+}
+
 // ConfigFileUsed returns the file used to populate the config registry.
 func ConfigFileUsed() string            { return v.ConfigFileUsed() }
 func (v *Viper) ConfigFileUsed() string { return v.configFile }
@@ -1554,14 +1564,6 @@ func castToMapStringInterface(
 	return tgt
 }
 
-func castMapStringSliceToMapInterface(src map[string][]string) map[string]interface{} {
-	tgt := map[string]interface{}{}
-	for k, v := range src {
-		tgt[k] = v
-	}
-	return tgt
-}
-
 func castMapStringToMapInterface(src map[string]string) map[string]interface{} {
 	tgt := map[string]interface{}{}
 	for k, v := range src {
@@ -1728,7 +1730,7 @@ func (v *Viper) AllKeys() []string {
 	m = v.flattenAndMergeMap(m, castMapStringToMapInterface(v.aliases), "")
 	m = v.flattenAndMergeMap(m, v.override, "")
 	m = v.mergeFlatMap(m, castMapFlagToMapInterface(v.pflags))
-	m = v.mergeFlatMap(m, castMapStringSliceToMapInterface(v.env))
+	m = v.mergeFlatMap(m, v.getAllEnvBoundAndSet())
 	m = v.flattenAndMergeMap(m, v.config, "")
 	m = v.flattenAndMergeMap(m, v.kvstore, "")
 	m = v.flattenAndMergeMap(m, v.defaults, "")

--- a/viper.go
+++ b/viper.go
@@ -184,9 +184,8 @@ type Viper struct {
 	configType string
 	envPrefix  string
 
-	automaticEnvApplied bool
-	envKeyReplacer      *strings.Replacer
-	allowEmptyEnv       bool
+	envKeyReplacer *strings.Replacer
+	allowEmptyEnv  bool
 
 	config         map[string]interface{}
 	override       map[string]interface{}
@@ -1036,16 +1035,6 @@ func (v *Viper) find(lcaseKey string) (interface{}, bool) {
 	}
 
 	// Env override next
-	if v.automaticEnvApplied {
-		// even if it hasn't been registered, if automaticEnv is used,
-		// check any Get request
-		if val, ok := v.getEnv(v.mergeWithEnvPrefix(lcaseKey)); ok {
-			return val, true
-		}
-		if nested && v.isPathShadowedInAutoEnv(path) != "" {
-			return nil, false
-		}
-	}
 	envkeys, exists := v.env[lcaseKey]
 	if exists {
 		for _, key := range envkeys {
@@ -1126,13 +1115,6 @@ func (v *Viper) IsSet(key string) bool {
 	lcaseKey := strings.ToLower(key)
 	_, found := v.find(lcaseKey)
 	return found
-}
-
-// AutomaticEnv has Viper check ENV variables for all.
-// keys set in config, default & flags
-func AutomaticEnv() { v.AutomaticEnv() }
-func (v *Viper) AutomaticEnv() {
-	v.automaticEnvApplied = true
 }
 
 // SetEnvKeyReplacer sets the strings.Replacer on the viper object

--- a/viper.go
+++ b/viper.go
@@ -1123,6 +1123,15 @@ func readAsCSV(val string) ([]string, error) {
 func IsSet(key string) bool { return v.IsSet(key) }
 func (v *Viper) IsSet(key string) bool {
 	lcaseKey := strings.ToLower(key)
+	val, _ := v.find(lcaseKey)
+	return val != nil
+}
+
+// IsSetIncludingNull checks to see if the key has been set in any of the data locations, even if it's set to null.
+// IsSetIncludingNull is case-insensitive for a key.
+func IsSetIncludingNull(key string) bool { return v.IsSet(key) }
+func (v *Viper) IsSetIncludingNull(key string) bool {
+	lcaseKey := strings.ToLower(key)
 	_, found := v.find(lcaseKey)
 	return found
 }

--- a/viper.go
+++ b/viper.go
@@ -1261,6 +1261,22 @@ func (v *Viper) Set(key string, value interface{}) {
 	deepestMap[lastKey] = value
 }
 
+// Unset removes a value set with Set
+// Unset is case-insensitive for a key.
+// Values which come from flags, config file, ENV or default can't be unset.
+func Unset(key string) { v.Unset(key) }
+func (v *Viper) Unset(key string) {
+	// If alias passed in, then set the proper override
+	key = v.realKey(strings.ToLower(key))
+
+	path := strings.Split(key, v.keyDelim)
+	lastKey := strings.ToLower(path[len(path)-1])
+	deepestMap := deepSearch(v.override, path[0:len(path)-1])
+
+	// unset innermost value
+	delete(deepestMap, lastKey)
+}
+
 // ReadInConfig will discover and load the configuration file from disk
 // and key/value stores, searching in one of the defined paths.
 func ReadInConfig() error { return v.ReadInConfig() }

--- a/viper_test.go
+++ b/viper_test.go
@@ -1818,3 +1818,33 @@ func TestKnownKeys(t *testing.T) {
 		t.Error("SetKnown didn't mark key as known")
 	}
 }
+
+func TestEmptySection(t *testing.T) {
+
+	var yamlWithEnvVars = `
+key:
+    subkey:
+another_key:
+`
+
+	v := New()
+	initConfig(v, "yaml", yamlWithEnvVars)
+	v.SetKnown("is_known")
+	v.SetDefault("has_default", true)
+
+	// AllKeys includes empty keys
+	keys := v.AllKeys()
+	assert.NotContains(t, keys, "key") // Only empty leaf nodes are returned
+	assert.Contains(t, keys, "key.subkey")
+	assert.Contains(t, keys, "another_key")
+	assert.NotContains(t, keys, "is_known")
+	assert.Contains(t, keys, "has_default")
+
+	// AllSettings includes empty keys
+	vars := v.AllSettings()
+	assert.NotContains(t, vars, "key") // Only empty leaf nodes are returned
+	assert.Contains(t, vars, "key.subkey")
+	assert.Contains(t, vars, "another_key")
+	assert.NotContains(t, vars, "is_known")
+	assert.Contains(t, vars, "has_default")
+}

--- a/viper_test.go
+++ b/viper_test.go
@@ -1825,6 +1825,7 @@ func TestEmptySection(t *testing.T) {
 key:
     subkey:
 another_key:
+empty_dict: {}
 `
 
 	v := New()
@@ -1837,6 +1838,7 @@ another_key:
 	assert.NotContains(t, keys, "key") // Only empty leaf nodes are returned
 	assert.Contains(t, keys, "key.subkey")
 	assert.Contains(t, keys, "another_key")
+	assert.Contains(t, keys, "empty_dict")
 	assert.NotContains(t, keys, "is_known")
 	assert.Contains(t, keys, "has_default")
 
@@ -1845,6 +1847,7 @@ another_key:
 	assert.NotContains(t, vars, "key") // Only empty leaf nodes are returned
 	assert.Contains(t, vars, "key.subkey")
 	assert.Contains(t, vars, "another_key")
+	assert.Contains(t, vars, "empty_dict")
 	assert.NotContains(t, vars, "is_known")
 	assert.Contains(t, vars, "has_default")
 }

--- a/viper_test.go
+++ b/viper_test.go
@@ -1809,6 +1809,7 @@ empty_dict: {}
 	initConfig(v, "yaml", yamlWithEnvVars)
 	v.SetKnown("is_known")
 	v.SetDefault("has_default", true)
+	v.BindEnv("is_bound")
 
 	// IsSet returns true for empty keys
 	assert.True(t, v.IsSet("key"))
@@ -1818,6 +1819,7 @@ empty_dict: {}
 	assert.True(t, v.IsSet("empty_dict"))
 	assert.False(t, v.IsSet("is_known"))
 	assert.True(t, v.IsSet("has_default"))
+	assert.False(t, v.IsSet("is_bound"))
 
 	// Get still returns nil for empty keys
 	assert.NotNil(t, v.Get("key"))
@@ -1826,6 +1828,7 @@ empty_dict: {}
 	assert.NotNil(t, v.Get("empty_dict"))
 	assert.Nil(t, v.Get("is_known"))
 	assert.NotNil(t, v.Get("has_default"))
+	assert.Nil(t, v.Get("is_bound"))
 
 	// AllKeys includes empty keys
 	keys := v.AllKeys()
@@ -1835,6 +1838,7 @@ empty_dict: {}
 	assert.Contains(t, keys, "empty_dict")
 	assert.NotContains(t, keys, "is_known")
 	assert.Contains(t, keys, "has_default")
+	assert.NotContains(t, keys, "is_bound")
 
 	// AllSettings includes empty keys
 	vars := v.AllSettings()
@@ -1844,4 +1848,5 @@ empty_dict: {}
 	assert.Contains(t, vars, "empty_dict")
 	assert.NotContains(t, vars, "is_known")
 	assert.Contains(t, vars, "has_default")
+	assert.NotContains(t, vars, "is_bound")
 }

--- a/viper_test.go
+++ b/viper_test.go
@@ -394,9 +394,6 @@ func TestEnv(t *testing.T) {
 	assert.Equal(t, "apple", v.Get("f"))
 	assert.Equal(t, "Cake", v.Get("name"))
 
-	v.AutomaticEnv()
-
-	assert.Equal(t, "crunk", v.Get("name"))
 }
 
 func TestEnvTransformer(t *testing.T) {
@@ -426,9 +423,6 @@ func TestMultipleEnv(t *testing.T) {
 	assert.Equal(t, "banana", v.Get("f"))
 	assert.Equal(t, "Cake", v.Get("name"))
 
-	v.AutomaticEnv()
-
-	assert.Equal(t, "crunk", v.Get("name"))
 }
 
 func TestEmptyEnv(t *testing.T) {
@@ -479,29 +473,12 @@ func TestEnvPrefix(t *testing.T) {
 	assert.Equal(t, "apple", v.Get("f"))
 	assert.Equal(t, "Cake", v.Get("name"))
 
-	v.AutomaticEnv()
-
-	assert.Equal(t, "crunk", v.Get("name"))
-}
-
-func TestAutoEnv(t *testing.T) {
-	v := New()
-	v.AutomaticEnv()
-	os.Setenv("FOO_BAR", "13")
-	assert.Equal(t, "13", v.Get("foo_bar"))
-}
-
-func TestAutoEnvWithPrefix(t *testing.T) {
-	v := New()
-	v.AutomaticEnv()
-	v.SetEnvPrefix("Baz")
-	os.Setenv("BAZ_BAR", "13")
-	assert.Equal(t, "13", v.Get("bar"))
 }
 
 func TestSetEnvKeyReplacer(t *testing.T) {
 	v := New()
-	v.AutomaticEnv()
+
+	v.BindEnv("refresh-interval")
 	os.Setenv("REFRESH_INTERVAL", "30s")
 
 	replacer := strings.NewReplacer("-", "_")

--- a/viper_test.go
+++ b/viper_test.go
@@ -1811,17 +1811,27 @@ empty_dict: {}
 	v.SetDefault("has_default", true)
 	v.BindEnv("is_bound")
 
-	// IsSet returns true for empty keys
+	// IsSet returns true for set and non-null keys
 	assert.True(t, v.IsSet("key"))
-	assert.True(t, v.IsSet("key.subkey"))
+	assert.False(t, v.IsSet("key.subkey")) // for backwards compat, but should be assert.True(t, v.IsSet("key.subkey"))
 	assert.False(t, v.IsSet("subkey"))
-	assert.True(t, v.IsSet("another_key"))
+	assert.False(t, v.IsSet("another_key")) // for backwards compat, but should be assert.True(t, v.IsSet("another_key"))
 	assert.True(t, v.IsSet("empty_dict"))
 	assert.False(t, v.IsSet("is_known"))
 	assert.True(t, v.IsSet("has_default"))
 	assert.False(t, v.IsSet("is_bound"))
 
-	// Get still returns nil for empty keys
+	// IsSetIncludingNull returns true for all set keys
+	assert.True(t, v.IsSetIncludingNull("key"))
+	assert.True(t, v.IsSetIncludingNull("key.subkey"))
+	assert.False(t, v.IsSetIncludingNull("subkey"))
+	assert.True(t, v.IsSetIncludingNull("another_key"))
+	assert.True(t, v.IsSetIncludingNull("empty_dict"))
+	assert.False(t, v.IsSetIncludingNull("is_known"))
+	assert.True(t, v.IsSetIncludingNull("has_default"))
+	assert.False(t, v.IsSetIncludingNull("is_bound"))
+
+	// Get still returns nil for not set and empty/null keys
 	assert.NotNil(t, v.Get("key"))
 	assert.Nil(t, v.Get("key.subkey"))
 	assert.Nil(t, v.Get("another_key"))
@@ -1830,7 +1840,7 @@ empty_dict: {}
 	assert.NotNil(t, v.Get("has_default"))
 	assert.Nil(t, v.Get("is_bound"))
 
-	// AllKeys includes empty keys
+	// AllKeys includes all keys, including empty/null
 	keys := v.AllKeys()
 	assert.NotContains(t, keys, "key") // Only empty leaf nodes are returned
 	assert.Contains(t, keys, "key.subkey")
@@ -1840,7 +1850,7 @@ empty_dict: {}
 	assert.Contains(t, keys, "has_default")
 	assert.NotContains(t, keys, "is_bound")
 
-	// AllSettings includes empty keys
+	// AllSettings includes all keys, including empty/null
 	vars := v.AllSettings()
 	assert.NotContains(t, vars, "key") // Only empty leaf nodes are returned
 	assert.Contains(t, vars, "key.subkey")

--- a/viper_test.go
+++ b/viper_test.go
@@ -1833,6 +1833,23 @@ empty_dict: {}
 	v.SetKnown("is_known")
 	v.SetDefault("has_default", true)
 
+	// IsSet returns true for empty keys
+	assert.True(t, v.IsSet("key"))
+	assert.True(t, v.IsSet("key.subkey"))
+	assert.False(t, v.IsSet("subkey"))
+	assert.True(t, v.IsSet("another_key"))
+	assert.True(t, v.IsSet("empty_dict"))
+	assert.False(t, v.IsSet("is_known"))
+	assert.True(t, v.IsSet("has_default"))
+
+	// Get still returns nil for empty keys
+	assert.NotNil(t, v.Get("key"))
+	assert.Nil(t, v.Get("key.subkey"))
+	assert.Nil(t, v.Get("another_key"))
+	assert.NotNil(t, v.Get("empty_dict"))
+	assert.Nil(t, v.Get("is_known"))
+	assert.NotNil(t, v.Get("has_default"))
+
 	// AllKeys includes empty keys
 	keys := v.AllKeys()
 	assert.NotContains(t, keys, "key") // Only empty leaf nodes are returned


### PR DESCRIPTION
In the Datadog Agent, we use the three methods expecting they will give consistent results. This means: if is `IsSet("key")` returns `true` we expect that key to appear in `AllSettings()` (used for example in the `agent config` command) and vice-versa. This PRs fixes such inconsistencies by adopting the behavior found in OTel and in  https://github.com/knadh/koanf across the three methods.

### Commit-by-commit changes

**The first commit** makes `AllSettings()` return keys that are explicitly set in the config but empty or null, eg:
```
key_one:
key_two: ~
```
Note that `AllKeys()` already returned those, so this makes `AllSettings()` consistent. The value associated to them in `AllSettings()` is `nil` in both cases. 

---

**The second commit** changes the behavior of both `AllKeys()` and `AllSettings()` to also include keys that are explicitly set to empty maps, eg:
```
key_set_to_empty_map: {}
```
This makes them consistent with `IsSet("key_set_to_empty_map")`, which would return true.

---
**The third commit** makes `IsSet("key")` return true for set-but-null (or set-but-empty, which is the same) keys.

---
**The fourth commit** removes one feature we are not using: `AutomaticEnv`. It simplifies the changes for the next commit.

---
**The fifth commit** makes `AllKeys()` and `AllSettings()` not return keys bound to env vars unless the env var is set.

Before the first commit here, `AllKeys()` would return bound-but-unset keys but `AllSettings()` wouldn't. The first commit made these two methods consistent by returning the keys in both cases, but that was inconsistent with `IsSet(key)` which doesn't return them. This last commit fixes that remaining inconsistency.

---
**The sixth commit** reverts the behavior for `IsSet()`, to keep backwards compatibility. I added a new `IsSetIncludingNull()` with the new behavior.
