### PR TITLE
Make AllKeys and AllSettings return set-but-empty keys

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -339,6 +339,16 @@ func (v *Viper) getEnv(key string) (string, bool) {
 	return val, ok && (v.allowEmptyEnv || val != "")
 }
 
+func (v *Viper) getAllEnvBoundAndSet() map[string]interface{} {
+	tgt := map[string]interface{}{}
+	for key, value := range v.env {
+		if _, ok := v.getEnv(v.mergeWithEnvPrefix(key)); ok {
+			tgt[key] = value
+		}
+	}
+	return tgt
+}
+
 // ConfigFileUsed returns the file used to populate the config registry.
 func ConfigFileUsed() string            { return v.ConfigFileUsed() }
 func (v *Viper) ConfigFileUsed() string { return v.configFile }
@@ -1571,14 +1581,6 @@ func castToMapStringInterface(
 	return tgt
 }
 
-func castMapStringSliceToMapInterface(src map[string][]string) map[string]interface{} {
-	tgt := map[string]interface{}{}
-	for k, v := range src {
-		tgt[k] = v
-	}
-	return tgt
-}
-
 func castMapStringToMapInterface(src map[string]string) map[string]interface{} {
 	tgt := map[string]interface{}{}
 	for k, v := range src {
@@ -1745,7 +1747,7 @@ func (v *Viper) AllKeys() []string {
 	m = v.flattenAndMergeMap(m, castMapStringToMapInterface(v.aliases), "")
 	m = v.flattenAndMergeMap(m, v.override, "")
 	m = v.mergeFlatMap(m, castMapFlagToMapInterface(v.pflags))
-	m = v.mergeFlatMap(m, castMapStringSliceToMapInterface(v.env))
+	m = v.mergeFlatMap(m, v.getAllEnvBoundAndSet())
 	m = v.flattenAndMergeMap(m, v.config, "")
 	m = v.flattenAndMergeMap(m, v.kvstore, "")
 	m = v.flattenAndMergeMap(m, v.defaults, "")

--- a/viper.go
+++ b/viper.go
@@ -1789,6 +1789,10 @@ func (v *Viper) flattenAndMergeMap(shadow map[string]bool, m map[string]interfac
 			shadow[strings.ToLower(fullKey)] = true
 			continue
 		}
+		if len(m2) == 0 {
+			// empty dict explicitly present in the map
+			shadow[strings.ToLower(fullKey)] = true
+		}
 		// recursively merge to shadow map
 		shadow = v.flattenAndMergeMap(shadow, m2, fullKey)
 	}

--- a/viper.go
+++ b/viper.go
@@ -1825,8 +1825,8 @@ func (v *Viper) AllSettings() map[string]interface{} {
 	for _, k := range v.AllKeys() {
 		value := v.Get(k)
 		if value == nil {
-			// should not happen, since AllKeys() returns only keys holding a value,
-			// check just in case anything changes
+			// Key set but empty, include it in the output as a null value
+			m[k] = nil
 			continue
 		}
 

--- a/viper_test.go
+++ b/viper_test.go
@@ -1818,3 +1818,33 @@ func TestKnownKeys(t *testing.T) {
 		t.Error("SetKnown didn't mark key as known")
 	}
 }
+
+func TestEmptySection(t *testing.T) {
+
+	var yamlWithEnvVars = `
+key:
+    subkey:
+another_key:
+`
+
+	v := New()
+	initConfig(v, "yaml", yamlWithEnvVars)
+	v.SetKnown("is_known")
+	v.SetDefault("has_default", true)
+
+	// AllKeys includes empty keys
+	keys := v.AllKeys()
+	assert.NotContains(t, keys, "key") // Only empty leaf nodes are returned
+	assert.Contains(t, keys, "key.subkey")
+	assert.Contains(t, keys, "another_key")
+	assert.NotContains(t, keys, "is_known")
+	assert.Contains(t, keys, "has_default")
+
+	// AllSettings includes empty keys
+	vars := v.AllSettings()
+	assert.NotContains(t, vars, "key") // Only empty leaf nodes are returned
+	assert.Contains(t, vars, "key.subkey")
+	assert.Contains(t, vars, "another_key")
+	assert.NotContains(t, vars, "is_known")
+	assert.Contains(t, vars, "has_default")
+}

--- a/viper_test.go
+++ b/viper_test.go
@@ -1825,6 +1825,7 @@ func TestEmptySection(t *testing.T) {
 key:
     subkey:
 another_key:
+empty_dict: {}
 `
 
 	v := New()
@@ -1837,6 +1838,7 @@ another_key:
 	assert.NotContains(t, keys, "key") // Only empty leaf nodes are returned
 	assert.Contains(t, keys, "key.subkey")
 	assert.Contains(t, keys, "another_key")
+	assert.Contains(t, keys, "empty_dict")
 	assert.NotContains(t, keys, "is_known")
 	assert.Contains(t, keys, "has_default")
 
@@ -1845,6 +1847,7 @@ another_key:
 	assert.NotContains(t, vars, "key") // Only empty leaf nodes are returned
 	assert.Contains(t, vars, "key.subkey")
 	assert.Contains(t, vars, "another_key")
+	assert.Contains(t, vars, "empty_dict")
 	assert.NotContains(t, vars, "is_known")
 	assert.Contains(t, vars, "has_default")
 }

--- a/viper_test.go
+++ b/viper_test.go
@@ -1832,6 +1832,7 @@ empty_dict: {}
 	initConfig(v, "yaml", yamlWithEnvVars)
 	v.SetKnown("is_known")
 	v.SetDefault("has_default", true)
+	v.BindEnv("is_bound")
 
 	// AllKeys includes empty keys
 	keys := v.AllKeys()
@@ -1841,6 +1842,7 @@ empty_dict: {}
 	assert.Contains(t, keys, "empty_dict")
 	assert.NotContains(t, keys, "is_known")
 	assert.Contains(t, keys, "has_default")
+	assert.NotContains(t, keys, "is_bound")
 
 	// AllSettings includes empty keys
 	vars := v.AllSettings()
@@ -1850,4 +1852,5 @@ empty_dict: {}
 	assert.Contains(t, vars, "empty_dict")
 	assert.NotContains(t, vars, "is_known")
 	assert.Contains(t, vars, "has_default")
+	assert.NotContains(t, vars, "is_bound")
 }


### PR DESCRIPTION
_This PR is a subset of #20 (I got too excited there and tried to also fix `IsSet`, but that breaks our Agent code)._


**The first commit** makes `AllSettings()` return keys that are explicitly set in the config but empty or null, eg:
```
key_one:
key_two: ~
```
Note that `AllKeys()` already returned those, so this makes `AllSettings()` consistent. The value associated to them in `AllSettings()` is `nil` in both cases. 

---

**The second commit** changes the behavior of both `AllKeys()` and `AllSettings()` to also include keys that are explicitly set to empty maps, eg:
```
key_set_to_empty_map: {}
```
This makes them consistent with `IsSet("key_set_to_empty_map")`, which would return true.

---

**The last commit** makes `AllKeys()` and `AllSettings()` not return keys bound to env vars unless the env var is set.

Before the first commit here, `AllKeys()` would return bound-but-unset keys but `AllSettings()` wouldn't. The first commit made these two methods consistent by returning the keys in both cases, but that was inconsistent with `IsSet(key)` which doesn't return them. This last commit fixes that remaining inconsistency.
