### PR TITLE
[CODEOWNERS] Add @DataDog/agent-shared-components as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# See https://help.github.com/articles/about-codeowners/ for syntax
+# Rules are matched bottom-to-top, so one team can own subdirectories
+# and another the rest of the directory.
+
+# All file changes should be reviewed by the maintainer team unless
+# specified otherwise
+*     @DataDog/agent-shared-components


### PR DESCRIPTION
Since this repo is owned by the whole team, any changes should ping all members
of this team for reviews.