### PR TITLE
return permissions errors when opening config files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        go: ['1.14', '1.15', '1.16']
+        go: ['1.17', '1.18']
     env:
       VERBOSE: 1
       GOFLAGS: -mod=readonly

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77
 	go.uber.org/zap v1.14.0 // indirect
 	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b // indirect
+	golang.org/x/sys v0.0.0-20220829200755-d48e67d00261 // indirect
 	golang.org/x/text v0.3.0 // indirect
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	google.golang.org/grpc v1.27.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -253,6 +253,8 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82 h1:ywK/j/KkyTHcdyYSZNXGjMwgmDSfjglYZ3vStQ/gSCU=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220829200755-d48e67d00261 h1:v6hYoSR9T5oet+pMXwUWkbiVqx/63mlHjefrHmxwfeY=
+golang.org/x/sys v0.0.0-20220829200755-d48e67d00261/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/viper.go
+++ b/viper.go
@@ -1947,7 +1947,6 @@ func (v *Viper) searchInPath(in string) (filename string, err error) {
 	for _, ext := range SupportedExts {
 		jww.DEBUG.Println("Checking for", filepath.Join(in, v.configName+"."+ext))
 		b, err := exists(v.fs, filepath.Join(in, v.configName+"."+ext))
-		fmt.Printf("%s %t %s\n", filepath.Join(in, v.configName+"."+ext), b, err)
 		if err != nil {
 			lastError = err
 		} else if b {

--- a/viper.go
+++ b/viper.go
@@ -1941,17 +1941,22 @@ func (v *Viper) getConfigFile() (string, error) {
 	return v.configFile, nil
 }
 
-func (v *Viper) searchInPath(in string) (filename string) {
+func (v *Viper) searchInPath(in string) (filename string, err error) {
+	var lastError error
 	jww.DEBUG.Println("Searching for config in ", in)
 	for _, ext := range SupportedExts {
 		jww.DEBUG.Println("Checking for", filepath.Join(in, v.configName+"."+ext))
-		if b, _ := exists(v.fs, filepath.Join(in, v.configName+"."+ext)); b {
+		b, err := exists(v.fs, filepath.Join(in, v.configName+"."+ext))
+		fmt.Printf("%s %t %s\n", filepath.Join(in, v.configName+"."+ext), b, err)
+		if err != nil {
+			lastError = err
+		} else if b {
 			jww.DEBUG.Println("Found: ", filepath.Join(in, v.configName+"."+ext))
-			return filepath.Join(in, v.configName+"."+ext)
+			return filepath.Join(in, v.configName+"."+ext), nil
 		}
 	}
 
-	return ""
+	return "", lastError
 }
 
 // Search all configPaths for any config file.
@@ -1959,13 +1964,23 @@ func (v *Viper) searchInPath(in string) (filename string) {
 func (v *Viper) findConfigFile() (string, error) {
 	jww.INFO.Println("Searching for config in ", v.configPaths)
 
+	var lastError error
 	for _, cp := range v.configPaths {
-		file := v.searchInPath(cp)
+		file, err := v.searchInPath(cp)
 		if file != "" {
 			return file, nil
 		}
+		if err != nil {
+			lastError = err
+		}
 	}
-	return "", ConfigFileNotFoundError{v.configName, fmt.Sprintf("%s", v.configPaths)}
+
+	// If there was no more-specific error, assume this was a not-found error
+	if lastError == nil {
+		lastError = ConfigFileNotFoundError{v.configName, fmt.Sprintf("%s", v.configPaths)}
+	}
+
+	return "", lastError
 }
 
 // Debug prints all configuration registries for debugging


### PR DESCRIPTION
This refactors findConfigFile to track the last error it encountered and return that instead of a synthetic ConfigFileNotFoundError when it cannot open a config file.

This should help produce more sensible configuration errors.