### PR TITLE
Add IsKnown function on Viper config

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -1265,6 +1265,14 @@ func (v *Viper) GetKnownKeys() map[string]interface{} {
 	return ret
 }
 
+// IsKnown returns whether the given key has been set as a known key
+func IsKnown(key string) bool { return v.IsKnown(key) }
+func (v *Viper) IsKnown(key string) bool {
+	key = strings.ToLower(key)
+	_, exists := v.knownKeys[key]
+	return exists
+}
+
 // Set sets the value for the key in the override register.
 // Set is case-insensitive for a key.
 // Will be used instead of values obtained via

--- a/viper_test.go
+++ b/viper_test.go
@@ -1879,3 +1879,18 @@ func TestKnownKeys(t *testing.T) {
 		t.Error("SetKnown didn't mark key as known")
 	}
 }
+
+func TestIsKnown(t *testing.T) {
+	v := New()
+
+	v.SetDefault("default", 45)
+	assert.True(t, v.IsKnown("default"))
+
+	v.SetKnown("known")
+	assert.True(t, v.IsKnown("known"))
+
+	v.SetKnown("UpperKnown")
+	assert.True(t, v.IsKnown("UpperKnown"))
+
+	assert.False(t, v.IsKnown("unknown"))
+}


### PR DESCRIPTION
We added the "known" keys in `viper` configs years ago, but no efficient way to check if a given config is known.

It would help detecting issues once the config starts being created more dynamicaly, eg. with the Serverless Agent, without having a huge CPU penalty of copying the full map every time.
