### PR TITLE
IsConfigured on an inner setting checks children's env vars

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -1211,7 +1211,22 @@ func IsConfigured(key string) bool { return v.IsConfigured(key) }
 func (v *Viper) IsConfigured(key string) bool {
 	lcaseKey := strings.ToLower(key)
 	val := v.find(lcaseKey, true)
-	return val != nil
+	if val != nil {
+		return true
+	}
+
+	// Have to check children for "inner node", since viper doesn't store env vars
+	for childkey, envvars := range v.env {
+		if childkey != key && strings.HasPrefix(childkey, key) {
+			for _, envvar := range envvars {
+				if _, found := v.getEnv(envvar); found {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
 }
 
 // AutomaticEnv has Viper check ENV variables for all.

--- a/viper_test.go
+++ b/viper_test.go
@@ -1011,6 +1011,15 @@ func TestIsConfigured(t *testing.T) {
 	assert.True(t, v.IsConfigured("clothing.shoes"))
 }
 
+func TestIsConfiguredUsingEnv(t *testing.T) {
+	v := New()
+	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	v.BindEnv("foo.bar")
+	t.Setenv("FOO_BAR", "baz")
+	assert.True(t, v.IsConfigured("foo"))
+	assert.True(t, v.IsConfigured("foo.bar"))
+}
+
 func TestDirsSearch(t *testing.T) {
 
 	root, config, cleanup := initDirs(t)


### PR DESCRIPTION
Because viper doesn't store env vars, when IsConfigured is called with a non-leaf setting, it needs to iterate the env vars to find if a child setting has been defined via env vars. Without this fix:

```
v.BindEnv("foo.bar")
os.Setenv("FOO_BAR", "baz")
v.IsConfigured("foo") // returns false
```

IsConfigured above returns false, which doesn't match its behavior for other sources of config data.