### PR TITLE
Revert invalid go version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        go: ['1.24.6']
+        go: ['1.25.11']
     env:
       VERBOSE: 1
       GOFLAGS: -mod=readonly

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/viper
 
-go 1.26
+go 1.25
 
 require (
 	github.com/fsnotify/fsnotify v1.4.7


### PR DESCRIPTION
We need to use 1.25 to be compatible OTLP agent